### PR TITLE
add GPlex tests with minimal Matriplex

### DIFF
--- a/GPlex.h
+++ b/GPlex.h
@@ -1,0 +1,157 @@
+#ifndef _GPLEX_H_
+#define _GPLEX_H_
+
+#include <cuda_runtime.h>
+#include <stdio.h>
+
+#include "gpu_utils.h"
+
+namespace Matriplex
+{
+typedef int idx_t;
+//------------------------------------------------------------------------------
+
+template<typename T, idx_t D1, idx_t D2, idx_t N>
+class Matriplex
+{
+public:
+   typedef T value_type;
+
+   enum
+   {
+      /// return no. of matrix rows
+      kRows = D1,
+      /// return no. of matrix columns
+      kCols = D2,
+      /// return no of elements: rows*columns
+      kSize = D1 * D2,
+      /// size of the whole matriplex
+      kTotSize = N * kSize
+   };
+
+   T fArray[kTotSize] __attribute__((aligned(64)));
+};
+
+
+template<typename T, idx_t D1, idx_t D2, idx_t N> using MPlex = Matriplex<T, D1, D2, N>;
+}
+
+//#include "gpu_constants.h"
+__device__ __constant__ static int gplexSymOffsets[7][36] =
+{
+  {}, 
+  {},
+  { 0, 1, 1, 2 },
+  { 0, 1, 3, 1, 2, 4, 3, 4, 5 }, // 3
+  {},
+  {},
+  { 0, 1, 3, 6, 10, 15, 1, 2, 4, 7, 11, 16, 3, 4, 5, 8, 12, 17, 6, 7, 8, 9, 13, 18, 10, 11, 12, 13, 14, 19, 15, 16, 17, 18, 19, 20 }
+};
+
+constexpr Matriplex::idx_t NN =  8; // "Length" of MPlex.
+
+constexpr Matriplex::idx_t LL =  6; // Dimension of large/long  MPlex entities
+constexpr Matriplex::idx_t HH =  3; // Dimension of small/short MPlex entities
+
+typedef Matriplex::Matriplex<float, LL, LL, NN>   MPlexLL;
+
+// GPU implementation of a Matriplex-like structure
+// The number of tracks is the fast dimension and is padded in order to have
+// consecutive and aligned memory accesses. For cached reads, this result in a
+// single memory transaction for the 32 threads of a warp to access 32 floats.
+// See:
+// http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#global-memory-3-0
+// In practice, The number of tracks (ntracks) is set to be MPT_SIZE
+template <typename M>
+struct GPlex { 
+  using T = typename M::value_type;
+  using value_type = T;
+
+  static const size_t kRows = M::kRows;
+  static const size_t kCols = M::kCols;
+  static const size_t kSize = M::kSize;
+
+  T* ptr;
+  size_t pitch, stride, N;
+
+  __device__ T  operator[](int xx) const { return ptr[xx]; }
+  __device__ T& operator[](int xx)       { return ptr[xx]; }
+
+  __device__ T& operator()(int n, int i, int j)       { return ptr[n + (i*kCols + j)*stride]; }
+  __device__ T  operator()(int n, int i, int j) const { return ptr[n + (i*kCols + j)*stride]; }
+
+  void allocate(size_t ntracks) {
+    N = ntracks;
+    cudaMallocPitch((void**)&ptr, &pitch, N*sizeof(T), kSize);
+    stride = pitch/sizeof(T);  // Number of elements
+  }
+  void free() {
+    cudaFree(ptr);
+    N = 0; pitch = 0; stride = 0;
+  }
+  //cudaMemcpy2D(d_msErr.ptr, d_msErr.pitch, msErr.fArray, N*sizeof(T),
+               //N*sizeof(T), HS, cudaMemcpyHostToDevice);
+
+  void copyAsyncFromHost(cudaStream_t& stream, const M& mplex) {
+    cudaMemcpy2DAsync(ptr, pitch, mplex.fArray, N*sizeof(T),
+                      N*sizeof(T), kSize, cudaMemcpyHostToDevice, stream);
+    cudaCheckError();
+  }
+  void copyAsyncToHost(cudaStream_t& stream, M& mplex) {
+    cudaMemcpy2DAsync(mplex.fArray, N*sizeof(T), ptr, pitch,
+                      N*sizeof(T), kSize, cudaMemcpyDeviceToHost, stream);
+    cudaCheckError();
+  }
+  void copyAsyncFromDevice(cudaStream_t& stream, GPlex<M>& gplex) {
+    cudaMemcpy2DAsync(ptr, pitch, gplex.ptr, gplex.pitch,
+                      N*sizeof(T), kSize, cudaMemcpyDeviceToDevice, stream);
+    cudaCheckError();
+  }
+};
+
+
+template <typename M>
+struct GPlexSym : GPlex<M> {
+  using T = typename GPlex<M>::T;
+  using GPlex<M>::kRows;
+  using GPlex<M>::kCols;
+  using GPlex<M>::stride;
+  using GPlex<M>::ptr;
+  __device__ size_t Off(size_t i) const { return gplexSymOffsets[kRows][i]; }
+  // Note: convenient but noticeably slower due to the indirection
+  __device__ T& operator()(int n, int i, int j)       { return ptr[n + Off(i*kCols + j)*stride]; }
+  __device__ T  operator()(int n, int i, int j) const { return ptr[n + Off(i*kCols + j)*stride]; }
+  //__device__ T& operator()(int n, int i, int j)       { return ptr[n + i*stride]; }
+  //__device__ T  operator()(int n, int i, int j) const { return ptr[n + i*stride]; }
+};
+
+using GPlexLL = GPlex<MPlexLL>;
+
+template <typename M>
+struct GPlexReg {
+  using T = typename M::value_type;
+  using value_type = T;
+
+  size_t kRows = M::kRows;
+  size_t kCols = M::kCols;
+  size_t kSize = M::kSize;
+
+  __device__ T  operator[](int xx) const { return arr[xx]; }
+  __device__ T& operator[](int xx)       { return arr[xx]; }
+
+  __device__ T& operator()(int n, int i, int j)       { return arr[i*kCols + j]; }
+  __device__ T  operator()(int n, int i, int j) const { return arr[i*kCols + j]; }
+
+  __device__ void SetVal(T v)
+  {
+     for (int i = 0; i < kSize; ++i)
+     {
+        arr[i] = v;
+     }
+  }
+
+  T arr[M::kSize];
+};
+
+using GPlexRegLL = GPlexReg<MPlexLL>;
+#endif  // _GPLEX_H_

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 objects = gplex_mul.o  gpu_utils.o
 
-all: $(objects)
+multorture: $(objects) multorture.cc
 	nvcc -o multorture multorture.cc $(objects)
 
 %.o: %.cu
 	nvcc -I ${CUB_ROOT}/include -c $< -o $@  
+
 clean:
 	rm -f *.o multorture

--- a/gplex_mul.cu
+++ b/gplex_mul.cu
@@ -1,10 +1,181 @@
+#define CUB_STDERR
 #include "gpu_utils.h"
+#include "cuda_profiler_api.h"
+#include "GPlex.h"
 
 #include <vector>
 #include <iostream>
 
 constexpr int block_size = 64;
 
+template <typename GPlex>
+__global__ void set_mem(GPlex a, float val,size_t N) {
+
+  for (int n = threadIdx.x + blockIdx.x * blockDim.x;
+       n < N;
+       n += blockDim.x * gridDim.x) {
+
+    for (int i = 0; i < GPlex::kSize; ++i) {
+      a(n, 0, i) = val;
+    }
+  }
+}
+
+template <typename GPlexNM, typename GPlexMP, typename GPlexNP>
+__global__ void naive_mult_kn(const __restrict__ GPlexNM a, const __restrict__ GPlexMP b, GPlexNP c, const int N)
+{
+  for (int n = threadIdx.x + blockIdx.x * blockDim.x;
+       n < N;
+       n += blockDim.x * gridDim.x) {
+
+
+    for (int i = 0; i < GPlexNM::kRows; ++i) {
+      for (int j = 0; j < GPlexMP::kCols; ++j) {
+        for (int k = 0; k < GPlexNM::kCols; ++k) {
+          c(n, i, j) += a(n, i, k) * b(n, k, j);
+        }
+      }
+    }
+  }
+}
+
+template <typename GPlexNM, typename GPlexMP, typename GPlexNP>
+__global__ void reg_c_mult_kn(const __restrict__ GPlexNM a, const __restrict__ GPlexMP b, GPlexNP c, const int N)
+{
+  for (int n = threadIdx.x + blockIdx.x * blockDim.x;
+       n < N;
+       n += blockDim.x * gridDim.x) {
+
+    for (int i = 0; i < GPlexNM::kRows; ++i) {
+      for (int j = 0; j < GPlexMP::kCols; ++j) {
+        float c_tmp = 0;
+        for (int k = 0; k < GPlexNM::kCols; ++k) {
+          c_tmp += a(n, i, k) * b(n, k, j);
+        }
+        c(n, i, j) += c_tmp;
+      }
+    }
+  }
+}
+
+template <typename GPlexNM, typename GPlexMP, typename GPlexNP>
+__global__ void shared_mult_kn(const __restrict__ GPlexNM a, const __restrict__ GPlexMP b, GPlexNP c, const int N)
+{
+  for (int n = threadIdx.x + blockIdx.x * blockDim.x;
+       n < N;
+       n += blockDim.x * gridDim.x) {
+
+    int tix = threadIdx.x;
+
+    __shared__ float sh_a[GPlexNM::kSize][block_size];
+    __shared__ float sh_b[GPlexMP::kSize][block_size];
+
+    for (int i = 0; i < GPlexNM::kSize; ++i) {
+      sh_a[i][tix] = a(n, 0, i);
+    }
+    for (int i = 0; i < GPlexNM::kSize; ++i) {
+      sh_b[i][tix] = b(n, 0, i);
+    }
+    __syncthreads();
+
+    for (int i = 0; i < GPlexNM::kRows; ++i) {
+      for (int j = 0; j < GPlexMP::kCols; ++j) {
+        float c_tmp = 0;
+        for (int k = 0; k < GPlexNM::kCols; ++k) {
+          /*c_tmp += a(n, i, k) * b(n, k, j);*/
+          c_tmp += sh_a[k + GPlexNM::kCols * i][tix] 
+            * sh_b[j + GPlexMP::kCols * k][tix];
+          /*c_tmp += sh_a[0][tix] ;*/
+            /** sh_b[j + GPlexMP::kCols * k][tix];*/
+        }
+        c(n, i, j) += c_tmp;
+      }
+    }
+  }
+}
+
+template <typename GPlexNM, typename GPlexMP, typename GPlexNP>
+__global__ void reg_mult_kn(const __restrict__ GPlexNM a, const __restrict__ GPlexMP b, GPlexNP c, const int N)
+{
+  for (int n = threadIdx.x + blockIdx.x * blockDim.x;
+       n < N;
+       n += blockDim.x * gridDim.x) {
+
+    GPlexRegLL reg_a;
+    GPlexRegLL reg_b;
+
+    for (int i = 0; i < GPlexNM::kSize; ++i) {
+      reg_a[i] = a(n, 0, i);
+    }
+    for (int i = 0; i < GPlexMP::kSize; ++i) {
+      reg_b[i] = b(n, 0, i);
+    }
+
+    for (int i = 0; i < GPlexNM::kRows; ++i) {
+      for (int j = 0; j < GPlexMP::kCols; ++j) {
+        float c_tmp = 0;
+        for (int k = 0; k < GPlexNM::kCols; ++k) {
+          c_tmp += reg_a(n, i, k) * reg_b(n, k, j);
+        }
+        c(n, i, j) += c_tmp;
+      }
+    }
+  }
+}
+
+
+void run_naive_mul(int N, int iter, bool pauseProf)
+{
+  /*constexpr int N = 3200000;//10000000;*/
+  /*constexpr int N = 100000;*/
+  GPlexLL a, b, c;
+
+  a.allocate(N);
+  b.allocate(N);
+  c.allocate(N);
+  cudaCheckErrorSync();
+
+  dim3 grid (((N-1)/block_size + 1), 1, 1);
+  dim3 block (block_size, 1, 1);
+
+  set_mem <<< grid, block >>> (a, 1.f , N);
+  set_mem <<< grid, block >>> (b, 1.f, N);
+  set_mem <<< grid, block >>> (c, 0.f, N);
+  cudaCheckErrorSync();
+
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    naive_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
+  cudaCheckErrorSync();
+
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    reg_c_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
+  cudaCheckErrorSync();
+
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    shared_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
+  cudaCheckErrorSync();
+
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    reg_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
+  cudaCheckErrorSync();
+
+  std::vector<float> h_c (N);
+  if (h_c[0] == 42)
+    std::cout << h_c[0] << std::endl;
+
+  a.free();
+  b.free();
+  c.free();
+  cudaCheckErrorSync();
+}
 
 __global__ void raw_naive_mult_kn(const float* a,
     const float* b, float* c, const int N)
@@ -36,7 +207,7 @@ __global__ void raw_reg_c_mult_kn(const float* a, const float* b,
         for (int k = 0; k < 6; ++k) {
           c_tmp += a[n + N*(i + 6*k)] * b[n + N*(k + 6*j)];
         }
-        c[n + N*(i + 6*j)] += c_tmp;
+        c[n + N*(i + 6*j)] = c_tmp;
       }
     }
   }
@@ -71,7 +242,7 @@ __global__ void raw_shared_mult_kn(const float* a, const float* b, float* c, con
           /*c_tmp += sh_a[0][tix] ;*/
             /** sh_b[j + GPlexMP::kCols * k][tix];*/
         }
-        c[n + N*(i + 6*j)] += c_tmp;
+        c[n + N*(i + 6*j)] = c_tmp;
       }
     }
   }
@@ -99,14 +270,14 @@ __global__ void raw_reg_mult_kn(const float* a, const float* b, float* c, const 
         for (int k = 0; k < 6; ++k) {
           c_tmp += reg_a[i+6*k] * reg_b[k+6+j];
         }
-        c[n + N*(i + 6*j)] += c_tmp;
+        c[n + N*(i + 6*j)] = c_tmp;
       }
     }
   }
 }
 
 
-void raw_run_naive_mul(int N)
+void raw_run_naive_mul(int N, int iter, bool pauseProf)
 {
   /*constexpr int N = 3200000;//10000000;*/
   /*constexpr int N = 100000;*/
@@ -128,13 +299,28 @@ void raw_run_naive_mul(int N)
   cudaMemset(c, 0, 36*N*sizeof(float));
   cudaCheckErrorSync();
 
-  raw_naive_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    raw_naive_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
   cudaCheckErrorSync();
-  raw_reg_c_mult_kn <<< grid, block >>> (a, b, c, N);
+
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    raw_reg_c_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
   cudaCheckErrorSync();
-  raw_shared_mult_kn <<< grid, block >>> (a, b, c, N);
+
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    raw_shared_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
   cudaCheckErrorSync();
-  raw_reg_mult_kn <<< grid, block >>> (a, b, c, N);
+
+  if (pauseProf) cudaProfilerStart();
+  for (int i = 0; i < iter; ++i)
+    raw_reg_mult_kn <<< grid, block >>> (a, b, c, N);
+  if (pauseProf) cudaProfilerStop();
   cudaCheckErrorSync();
 
   std::vector<float> h_c (N);

--- a/gplex_mul.h
+++ b/gplex_mul.h
@@ -1,4 +1,5 @@
 #pragma once
 
-void raw_run_naive_mul(int N);
+void run_naive_mul(int N, int iter, bool pauseProf);
+void raw_run_naive_mul(int N, int iter, bool pauseProf);
 void propagation_test(int N);

--- a/multorture.cc
+++ b/multorture.cc
@@ -5,8 +5,14 @@ int main() {
 
   {
     size_t testN = 10000;
+    int testIter = 1;
+    bool pauseProf = false;
+
+    printf("Run run_naive_mul\n");
+    run_naive_mul(testN, testIter, pauseProf);
+
     printf("Run raw_run_naive_mul\n");
-    raw_run_naive_mul(testN);
+    raw_run_naive_mul(testN, testIter, pauseProf);
   }
 
   printf("Bye\n");


### PR DESCRIPTION
This adds a minimal Matriplex with just enough to instantiate a GPlex, and restores the GPlex tests in Matthieu's original.  Also fixes a bug that added an extra addition to several tests, fixes a bug in the Makfile, and adds an optional loop around each test and the option to turn off profiling for the sync between tests.

The value of Matriplex::NN should be reviewed.