### PR TITLE
make sure tests pass for testIter > 1 and non-standard widths

### DIFF
--- a/gplex_mul.h
+++ b/gplex_mul.h
@@ -1,7 +1,9 @@
 #pragma once
 //#define EIGEN_TEST
 
-void run_naive_mul(int N, int iter);
-void raw_run_naive_mul(int N, int iter);
-void eigen_run_naive_mul(int N, int iter);
+void run_naive_mul(int iter);
+void raw_run_naive_mul(int iter);
+void eigen_run_naive_mul(int iter);
 void propagation_test(int N);
+
+constexpr int Nwidth = 7168;

--- a/multorture.cc
+++ b/multorture.cc
@@ -4,18 +4,18 @@
 int main() {
 
   {
-    size_t testN = 7168;
+    // size_t testN = 7168; has moved to gplex_mul.h
     int testIter = 1;
 
     printf("Run run_naive_mul\n");
-    run_naive_mul(testN, testIter);
+    run_naive_mul(testIter);
 
     printf("Run raw_run_naive_mul\n");
-    raw_run_naive_mul(testN, testIter);
+    raw_run_naive_mul(testIter);
 
 #ifdef EIGEN_TEST
     printf("Run eigen_run_naive_mul\n");
-    eigen_run_naive_mul(testN, testIter);
+    eigen_run_naive_mul(testIter);
 #endif
   }
 


### PR DESCRIPTION
   * reset results array for the naive tests that use '+=' instead of '=' for results, so that testIter > 1 passes
   * make raw_reg_c_mult_loop_unroll_const_kn NN consistent with global value
